### PR TITLE
update rhino version and fix the interpreter accordingly for better compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>org.mozilla</groupId>
         <artifactId>rhino</artifactId>
-        <version>1.7R4</version>
+        <version>1.7.15</version>
       </dependency>
 
       <dependency>

--- a/src/main/java/org/jvoicexml/processor/SemanticsInterpreter.java
+++ b/src/main/java/org/jvoicexml/processor/SemanticsInterpreter.java
@@ -165,6 +165,9 @@ public class SemanticsInterpreter implements TreeWalker<ChartNode> {
       addline("return out;");
       close();
       addline("rules." + ruleName + "= rule_" + node.getId() + "();");
+      // this works in older versions of rhino
+      // addline("rules.latest = rule_"+node.getId());
+      addline("rules.latest = () => rules."+ruleName+";");
     }
   }
 }


### PR DESCRIPTION
I was having compatibility issues getting some relatively complex grammars in use with other (cough) interpreters to work.  Please consider this update which bumps the rhino version and makes a minor change to rules.latest.